### PR TITLE
Add venv pip location in Windows environments

### DIFF
--- a/build.py
+++ b/build.py
@@ -39,6 +39,7 @@ def possible_pip_binary_paths(config):
     files = [
         os.path.join(config.base_dir, 'env', 'bin', 'pip'),
         os.path.join(config.base_dir, 'env', 'bin', 'pip.exe'),
+        os.path.join(config.base_dir, 'env', 'Scripts', 'pip.exe')
     ]
     if not config.enter_env:
         for path in [shutil.which('pip'), shutil.which('pip.exe')]:


### PR DESCRIPTION
`build.py` fails during execution of `install_env()`  because `possible_pip_binary_paths()`  doesn't include `Scripts/` in any of the search paths, which is only a problem for virtual environments created on Windows-based system.   PR adds that path to the list of possible `pip` locations. 
