### PR TITLE
File Expanding Utility for Nested Code Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ env
 .screeps-password
 .screeps-email
 config.json
+__py_build__/
 
 # Misc files #
 ##############

--- a/build.py
+++ b/build.py
@@ -102,7 +102,7 @@ class Configuration:
 
     @property
     def source_dir(self):
-        """str: Target directory for Transcrypt build process"""
+        """:rtype: str"""
         if self.flatten:
             return os.path.join(self.base_dir, 'src', '__py_build__')
         else:

--- a/file_expander.py
+++ b/file_expander.py
@@ -1,0 +1,171 @@
+"""File Expansion of Nested screeps Source Code.
+
+This package provides file expansion operations that targets screeps code
+written in Python in order to allow files to be organized in a nested directory
+structure.
+
+Every time Transcrypt is run, user generated .py source code will be copied so
+that they all sit directly under __py_build__.  Only new/updated files will
+actually be copied; unmodified files are not replaced in __py_build__. Files can
+reside directly under src/, or in subdirectories under src/.
+
+The -xpath option available through Transcrypt already provides this
+functionality; this package serves as a replacement for anyone experiencing
+problems with Transcrypt recognizing python modules stored in sub-folders, or
+for those looking for an alternative to -xpath itself."""
+
+import pathlib
+import shutil
+import filecmp
+
+
+class FileExpander:
+    """Class for managing file expansion operations.
+
+    Attributes:
+        base_dir (:obj:pathlib.Path): concrete Path object of the
+            screeps-starter-python directory
+        build_dir (:obj:pathlib.Path): concrete Path object of the __py_build__
+            directory
+
+    """
+
+    def __init__(self, base_dir):
+        """
+        Args:
+            base_dir (str): Absolute path of the screeps-starter-python
+                directory
+        """
+        self.base_dir = pathlib.Path(base_dir).joinpath('src')
+        self.build_dir = self.verify_build_directory()
+
+    def verify_build_directory(self):
+        """Verifies __py_build__, and __py_build__/defs exist.  While
+        __py_build__ is simply created if it's missing, defs/ is copied directly
+        from src/.
+
+        Returns:
+            (:obj:pathlib.Path): concrete Path object of the __py_build__
+            directory
+        """
+
+        build_directory = self.base_dir.joinpath('__py_build__')
+
+        defs_source_directory = self.base_dir.joinpath('defs')
+        defs_build_directory = build_directory.joinpath('defs')
+
+        defs_source_path = str(defs_source_directory.absolute())
+        defs_build_path = str(defs_build_directory.absolute())
+
+        if not build_directory.is_dir():
+            build_directory.mkdir(exist_ok=True)
+
+        if not defs_build_directory.is_dir():
+            shutil.copytree(defs_source_path, defs_build_path)
+
+        else:
+            if not self.verify_defs_integrity(defs_build_directory, defs_source_directory):
+                shutil.copytree(defs_source_path, defs_build_path)
+
+        return build_directory
+
+    @staticmethod
+    def verify_defs_integrity(build_dir, source_dir):
+        """Verifies the contents of the defs file in src/defs against
+        src/__py_build__/defs.  This ensures that the defs file directly under
+        src/ is reflected at all times in the repository targeted by Transcrypt.
+
+        This prevents the user from having to manually copy over the defs folder
+        after updates.  Additionally, it allows them to make modifications
+        locally while maintaining the correct folder structure.
+
+        Returns:
+            bool: True if all files match, else immediately returns false.
+
+        """
+
+        defs_source_files = [str(f.absolute()) for f in source_dir.glob('**/*.py')]
+        defs_build_files = [str(f.absolute()) for f in build_dir.glob('**/*.py')]
+
+        if len(defs_source_files) != len(defs_build_files):
+            return False
+
+        for build_file in sorted(defs_build_files):
+            for src_file in sorted(defs_source_files):
+                if filecmp.cmp(build_file, src_file):
+                    break
+            else:
+                return False
+
+        return True
+
+    def expand_files(self):
+        """Copies user generated files directly under src/, and nested in
+        sub-folders under src/, to the __py_build__ folder.  Only new and/or
+        modified files are copied; the original files, and their directory
+        structure, are not modified.
+
+        Returns:
+            int: Total number of files copied to __py_build__
+        """
+
+        target_files = self.find_target_file_paths()
+
+        copied_files = 0
+        for target in target_files:
+            partner = self.build_dir.joinpath(target.name)
+            target_path, partner_path = str(target.absolute()), str(partner.absolute())
+
+            if not (partner.is_file() and filecmp.cmp(target_path, partner_path)):
+                shutil.copy2(target_path, partner_path)
+                copied_files += 1
+
+        return copied_files
+
+    def find_target_file_paths(self):
+        """Finds all potential target files for the file expansion operation.
+        Files and/or directories under the exclusions list are ignored.
+
+        The files discovered by this method only represent objects that will be
+        checked by self.expand_files() and not the final output of the copy
+        operation.
+
+        Returns:
+            obj:`list` of :obj:`pathlib.Path`: All candidates for the final copy
+                operation targeting __py_build__
+        """
+
+        exclusions = [
+            '__pycache__',
+            '__javascript__',
+            '__py_build__',
+            '.idea',
+            '.git',
+            'defs'
+        ]
+
+        target_files, target_directories = [], []
+        for file_object in self.base_dir.iterdir():
+
+            if not any(entry in file_object.name for entry in exclusions):
+                if file_object.is_file():
+                    target_files.append(file_object)
+                else:
+                    target_directories.append(file_object)
+
+        # Directories processed separately to avoid performing glob on all of src/
+        for directory in target_directories:
+            for file in directory.glob('**/*.py'):
+                target_files.append(file)
+
+        return target_files
+
+
+def test_methods():
+    base_dir = pathlib.Path(__file__).parent
+    data_logger = FileExpander(base_dir)
+    data_logger.expand_files()
+
+
+if __name__ == "__main__":
+    test_methods()

--- a/file_expander.py
+++ b/file_expander.py
@@ -22,31 +22,25 @@ import filecmp
 class FileExpander:
     """Class for managing file expansion operations.
 
-    Attributes:
-        base_dir (:obj:pathlib.Path): concrete Path object of the
-            screeps-starter-python directory
-        build_dir (:obj:pathlib.Path): concrete Path object of the __py_build__
-            directory
+        :type base_dir: pathlib.Path
+        :type build_dir: pathlib.Path
 
     """
 
     def __init__(self, base_dir):
         """
-        Args:
-            base_dir (str): Absolute path of the screeps-starter-python
-                directory
+        :param base_dir: absolute path of the screeps-starter-python directory
+        :type base_dir: str
         """
         self.base_dir = pathlib.Path(base_dir).joinpath('src')
         self.build_dir = self.verify_build_directory()
 
     def verify_build_directory(self):
-        """Verifies __py_build__, and __py_build__/defs exist.  While
-        __py_build__ is simply created if it's missing, defs/ is copied directly
-        from src/.
+        """Verifies existence and contents of __py_build__ directory. Missing
+        directories are either created, or copied from its counterpart in src/""
 
-        Returns:
-            (:obj:pathlib.Path): concrete Path object of the __py_build__
-            directory
+        :return: concrete Path object of the __py_build__ directory
+        :rtype: pathlib.Path
         """
 
         build_directory = self.base_dir.joinpath('__py_build__')
@@ -71,17 +65,14 @@ class FileExpander:
 
     @staticmethod
     def verify_defs_integrity(build_dir, source_dir):
-        """Verifies the contents of the defs file in src/defs against
-        src/__py_build__/defs.  This ensures that the defs file directly under
-        src/ is reflected at all times in the repository targeted by Transcrypt.
+        """Verifies integrity of defs/ folder in __py_build__
 
-        This prevents the user from having to manually copy over the defs folder
-        after updates.  Additionally, it allows them to make modifications
-        locally while maintaining the correct folder structure.
+        If any file in __py_build__/defs can't be matched against a file in
+        src/defs, the method immediately returns as False.  The method will also
+        return false if the total number of files differs.
 
-        Returns:
-            bool: True if all files match, else immediately returns false.
-
+        :returns: result of the the file and directory comparisons
+        :rtype: bool
         """
 
         defs_source_files = [str(f.absolute()) for f in source_dir.glob('**/*.py')]
@@ -100,13 +91,16 @@ class FileExpander:
         return True
 
     def expand_files(self):
-        """Copies user generated files directly under src/, and nested in
-        sub-folders under src/, to the __py_build__ folder.  Only new and/or
-        modified files are copied; the original files, and their directory
-        structure, are not modified.
+        """Creates a flattened file structure of all user-defined screeps code
 
-        Returns:
-            int: Total number of files copied to __py_build__
+        All user-defined .py files in src/ regardless if they are in sub-folders
+        or directly under src/ will be copied to __py_build__.  The copy
+        operation places all files directly under __py_build__; the original
+        files are not modified or moved. Copy attempts will only be directed at
+        new and/or updated files.
+
+        :return: total number of files copied to __py_build__
+        :rtype: int
         """
 
         target_files = self.find_target_file_paths()
@@ -123,16 +117,15 @@ class FileExpander:
         return copied_files
 
     def find_target_file_paths(self):
-        """Finds all potential target files for the file expansion operation.
-        Files and/or directories under the exclusions list are ignored.
+        """Finds all potential target files for the file expansion operation
 
-        The files discovered by this method only represent objects that will be
-        checked by self.expand_files() and not the final output of the copy
-        operation.
+        Files and/or directories under the exclusions list are ignored. Any
+        files matching search criteria are only candidates for the copy process;
+        the list resulting from this method does not represent the list of all
+        files that will be copied to __py_build__.
 
-        Returns:
-            obj:`list` of :obj:`pathlib.Path`: All candidates for the final copy
-                operation targeting __py_build__
+       :return: All files to be checked by self.expand_files
+       :rtype: list[pathlib.Path]
         """
 
         exclusions = [
@@ -159,13 +152,3 @@ class FileExpander:
                 target_files.append(file)
 
         return target_files
-
-
-def test_methods():
-    base_dir = pathlib.Path(__file__).parent
-    data_logger = FileExpander(base_dir)
-    data_logger.expand_files()
-
-
-if __name__ == "__main__":
-    test_methods()


### PR DESCRIPTION
This serves as an alternative to Transcrypts `-xpath` option, primarily for those who have problems with getting Transcrypt to recognize nested modules.

`file_expander.py` is composed of a single class, `FileExpander`, that will search for user-created screeps code under `screeps-starter-python/src/`.  The files can be directly in `src/`, or in any type of nested directory structure within `src/`.  By providing `-e` or `--expand-files` to `build.py`, before Transcrypt processes anything, all of the code files meeting the above description are copied to a `__py_build__` folder, which is located in `src/`.  The copy process flattens any nested folder structure created by the user and stores all files directly under `__py_build__`.  The user's original files remain untouched, and only updated files are actually copied.  

The following actions are automatically handled:

- Creation of the `__py_build__` folder if missing
- Copying of required folders (and their contents), like `defs/` if not found in `__py_build__`
- Automatic updating of `defs/` files and subdirectories in `__py_build__`: this ensures the file is updated in `__py_build__` if a newer version is released through `screeps-starter-python`, or if the user wishes to make custom changes
 
The build process, in my experience, isn't affected by this module.  `filecmp` caches previous comparisons for improved performance, and `shutil` is implemented so that it won't even attempt to copy a file if it hasn't been modified.

`build.py` defaults to the original build process, so those who don't want to use it don't have to make any changes to their workflow.  If desired, this can be used simultaneously with the standard build process as the `-e` switch directs which folder Transcrypt should target.  `__py_build__` can be deleted at any time without consequence.  