### PR TITLE
Update transcrypt version and update python requirement to 3.7.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 __pycache__/
 *.py[cod]
 __javascript__/
+__target__/
 target/
 
 # Git #

--- a/book/setup.md
+++ b/book/setup.md
@@ -7,10 +7,12 @@ transpile Python into JavaScript set up.
 The `./build.py` script does the majority of the work, from setting up a new environment to building/publishing the
 binary to the screeps server. However, you will need to install some dependencies:
 
-- `python-3.5` - Transcrypt works natively with Python 3.5, so you will need this version installed. Python 3.4 is more
-  widely available, but will not work for our purposes.
+- `python-3.7` - Transcrypt works natively with Python 3.7, so you will need this version installed.
+  - You can make `python-3.5` work, but you will need to use an older version of the transcrypt
+    interpreter. Modify `requirements.txt` to use `@screeps-transcrypt-0.1.12` rather than
+    `@screeps-transcrypt-0.1.14`.
 - `pip` - Make sure you have a Python 3.* version of `pip` installed as well. While `pip-3.4` is fine, you do need at
-  least that in order to make a `python-3.5` virtualenv. You can check your pip version with `pip --version`, and
+  least that in order to make a `python-3.7` virtualenv. You can check your pip version with `pip --version`, and
   depending on how it was installed, you may need to use `pip3`, `pip-3`, `pip3.4` or `pip-3.4` instead.
 
 After you have those set up, you'll need to install `virtualenv`:
@@ -42,7 +44,7 @@ rest of the guide must be entered in the terminal created by `Anaconda Prompt`.
 
 Enter the following commands in the order listed:
 
-  1. `conda create -n screeps python=3.5`
+  1. `conda create -n screeps python=3.7`
   2. `activate screeps`
   3. `conda install git`
   4. `conda install -c anaconda virtualenv`

--- a/build.py
+++ b/build.py
@@ -266,10 +266,19 @@ def install_env(config):
 
         if not os.path.exists(env_dir):
             print("creating virtualenv environment...")
-            if sys.version_info >= (3, 5):
-                args = ['virtualenv', '--system-site-packages', env_dir]
+
+            if sys.version_info >= (3, 7):
+                python_name = os.path.basename(sys.executable)
             else:
-                args = ['virtualenv', '-p', 'python3.5', '--system-site-packages', env_dir]
+                python_name = 'python3.7'
+
+            args = [
+                sys.executable,
+                '-m', 'virtualenv',
+                '-p', 'python3.7',
+                '--system-site-packages',
+                env_dir,
+            ]
 
             ret = subprocess.Popen(args, cwd=config.base_dir).wait()
 

--- a/build.py
+++ b/build.py
@@ -143,7 +143,7 @@ def run_transcrypt(config):
     """
     transcrypt_executable = config.transcrypt_executable()
 
-    source_main = os.path.join(config.source_dir, 'main.py')
+    source_main = os.path.join(config.source_dir, 'main')
 
     if config.clean_build:
         cmd_args = transcrypt_clean_args
@@ -176,16 +176,19 @@ def copy_artifacts(config):
         else:
             raise
 
-    shutil.copyfile(os.path.join(config.source_dir, '__javascript__', 'main.js'),
-                    os.path.join(dist_directory, 'main.js'))
+    with os.scandir(os.path.join(config.source_dir, '__target__')) as scan:
+        for entry in scan:
+            if entry.is_file():
+                shutil.copy_file(entry.path, os.path.join(dist_directory, entry.name))
 
     js_directory = os.path.join(config.base_dir, 'js_files')
 
     if os.path.exists(js_directory) and os.path.isdir(js_directory):
-        for name in os.listdir(js_directory):
-            source = os.path.join(js_directory, name)
-            dest = os.path.join(dist_directory, name)
-            shutil.copy2(source, dest)
+        with os.scandir(js_directory) as scan:
+            for entry in scan:
+                source = scan.path
+                dest = os.path.join(dist_directory, scan.name)
+                shutil.copy2(source, dest)
 
 
 def build(config):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+git://github.com/daboross/Transcrypt.git@screeps-transcrypt-0.1.12#egg=transcrypt
+git+git://github.com/daboross/Transcrypt.git@screeps-transcrypt-0.1.14#egg=transcrypt


### PR DESCRIPTION
This should fix #14. However, I have not done extensive testing!

If you'd like to test this, just edit your local `requirements.txt`, then delete or rename `env/` to force `build.py` to re-download transcrypt.

`requirements.txt` should be:

```
git+git://github.com/daboross/Transcrypt.git@import-export-attempt-1#egg=transcrypt
```

You'll also want to copy the changes to `build.py`. The new one in this PR is at https://raw.githubusercontent.com/daboross/screeps-starter-python/update-transcrypt/build.py.


---

To undo, just delete/rename `env` again and undo the changes to `requirements.txt` and `build.py`.