### PR TITLE
Added X-Token support to build.py

### DIFF
--- a/book/setup.md
+++ b/book/setup.md
@@ -67,6 +67,8 @@ upload files directly to the screeps server after building.
 
 Copy the contents of `config.default.json` into `config.json`. [Generate an auth-token](https://docs.screeps.com/auth-tokens.html#Using-Auth-Tokens) with full access rights through your screep's account management page.  Existing tokens with a matching access level can also be used.  Copy the token and paste it to the `token` key in `config.json`.
 
+Alternatively, you can use your username and password for authentication by removing the `token` entry, and adding `username` and `password` fields to `config.json`.
+
 Following that, you're all set up! `build.py` will automatically download and install the rest of the dependencies into
 a local environment when it is first run.
 

--- a/book/setup.md
+++ b/book/setup.md
@@ -65,8 +65,7 @@ Post Installation Steps
 The last step to setting up `screeps-game-api` is to create and configure the build. This will allow `build.py` to
 upload files directly to the screeps server after building.
 
-Copy `config.default.json` into a file `config.json`, enter your username or email into the file, and enter your
-screeps (not steam) password in the file.
+Copy the contents of `config.default.json` into `config.json`. [Generate an auth-token](https://docs.screeps.com/auth-tokens.html#Using-Auth-Tokens) with full access rights through your screep's account management page.  Existing tokens with a matching access level can also be used.  Copy the token and paste it to the `token` key in `config.json`.
 
 Following that, you're all set up! `build.py` will automatically download and install the rest of the dependencies into
 a local environment when it is first run.

--- a/build.py
+++ b/build.py
@@ -68,6 +68,7 @@ class Configuration:
         :type config_json: dict[str, str | bool]
         """
         self.base_dir = base_dir
+        self.token = config_json.get('token')
         self.username = config_json.get('username') or config_json.get('email')
         self.password = config_json['password']
         self.branch = config_json.get('branch', 'default')
@@ -223,14 +224,14 @@ def upload(config):
 
     post_data = json.dumps({'modules': module_files, 'branch': config.branch}).encode('utf-8')
 
-    auth_pair = config.username.encode('utf-8') + b':' + config.password.encode('utf-8')
+    headers = {'Content-Type': b'application/json; charset=utf-8'}
+    if config.token:
+        headers['X-Token'] = config.token.encode('utf-8')
+    else:
+        auth_pair = config.username.encode('utf-8') + b':' + config.password.encode('utf-8')
+        headers['Authorization'] = b'Basic ' + base64.b64encode(auth_pair)
 
-    headers = {
-        'Content-Type': b'application/json; charset=utf-8',
-        'Authorization': b'Basic ' + base64.b64encode(auth_pair),
-    }
     request = urllib.request.Request(post_url, post_data, headers)
-
     if config.url != 'https://screeps.com':
         print("uploading files to {}, branch {}{}..."
               .format(config.url, config.branch, " on PTR" if config.ptr else ""))

--- a/config.default.json
+++ b/config.default.json
@@ -1,6 +1,5 @@
 {
-    "email": "youremail@here.com",
-    "password": "plain-text-password",
+    "token": "token-created-from-account-management",
     "branch": "default",
     "ptr": false
 }


### PR DESCRIPTION
`build.py` now supports X-Tokens.  If token, username, and password are present, the token will be used.  Modified `config.default.json` to include a `token` entry instead of `username` and `password`, and removed references to entries in documentation book, which were replaced by auth-token setup instructions.  Basic access authentication still supported by `build.py` and these changes will not affect existing users.  

**Reasoning**:
This [announcement](https://blog.screeps.com/2017/12/auth-tokens/) last year provided auth tokens as an alternative to basic access authentication for access to screeps user endpoints.  In February, basic access authentication was removed, with the exception of the `/api/user/code/` endpoint, which is why `build.py` remains unaffected.  

[The discussion here](https://screeps.com/forum/topic/2052/auth-tokens/86) posed good points for keeping basic access around for code pushing, and I agree users should have a choice in what authentication method they use.  However, I also feel using tokens over usernames and password is inherently more secure and should be supported over usernames and passwords going forward.  