### PR TITLE
Update transcrypt requirement to git+https for easier first time setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+git://github.com/daboross/Transcrypt.git@screeps-transcrypt-0.3.3#egg=transcrypt
+git+https://github.com/daboross/Transcrypt.git@screeps-transcrypt-0.3.3#egg=transcrypt


### PR DESCRIPTION
A common issue with setting up screeps-starter-python for the first time seems to be that people have trouble when build.py tries to clone transcrypt.

Examples:
https://discord.com/channels/860665589738635336/865973556696580106/962147890535477338
https://discord.com/channels/860665589738635336/865973556696580106/972329184485576704
https://discord.com/channels/860665589738635336/865973556696580106/981826442449027134

If there's this many people struggling and posting on the discord, there are surely plenty more struggling then giving up altogether.

This pr makes the fix for the issue the default, so more people can have a seamless experience with screeps and python out of the box.